### PR TITLE
making it so you don't have to type out Id when doing an assign

### DIFF
--- a/fp.hs
+++ b/fp.hs
@@ -59,7 +59,7 @@ data TERMLANGX = NumX Int
               | DerefX TERMLANGX
               | SeqX TERMLANGX TERMLANGX
               | FixX TERMLANGX
-              | AssignX TERMLANGX TERMLANGX
+              | AssignX String TERMLANGX
                 deriving (Show,Eq)
 
 data VALUELANG where
@@ -326,7 +326,7 @@ elab (SetX l v) = (Set (elab l) (elab v))
 elab (DerefX l) = (Deref (elab l))
 elab (SeqX l r) = (Seq (elab l) (elab r))
 elab (FixX f) = (Fix (elab f))
-elab (AssignX l r) = (Set (elab l) (elab r))
+elab (AssignX l r) = (Set (Id l) (elab r))
 
 -- Interpretor
 interp :: TERMLANGX -> Maybe (Store, VALUELANG)


### PR DESCRIPTION
-use case --> interp (BindX 'x' (NewX (NumX 4)) (SeqX (AssignX 'x' (NumX 5)) (Deref (IdX 'x')))))