### PR TITLE
Allow us to call 'App' on derefed function

### DIFF
--- a/fp.hs
+++ b/fp.hs
@@ -255,9 +255,15 @@ typeof g (Lambda i d b) = do {
 }
 typeof g (App f a) = do {
     a' <- typeof g a;
-    d :->: r <- typeof g f;
-    if d == a' then return r
-    else Nothing
+    if (typeof g f == Just TTop) 
+      then return a'
+      else (
+        do {
+          d :->: r <- typeof g f;
+          if d == a' then return r
+          else Nothing
+        }
+      )
 }
 typeof g (Bind i v b) = do {
     v' <- typeof g v;


### PR DESCRIPTION
I ran into an issue while testing the following:

`interp (BindX "x" (NewX (LambdaX "v" TNum (PlusX (IdX "v") (NumX 1)))) (AppX (DerefX (IdX "x")) (NumX 1)))`

This was failing out `typeof` method.  The reason why was that in the typeof constructor for `AppX`, we were forcing the type to be of the form `d :->: r`.  This makes sense except that when we put a Lambda into our store, than retrieve it out, the type is `TTop` which COULD BE a lambda but is not of the form `d :->: r`.  The code I added checks if the type is `TTop` and returns the parameter's type if so.  I did not notice any issues in terms of type failure from this change, but would appreciate if someone could test it out.